### PR TITLE
Add lock to services

### DIFF
--- a/src/services/adopterService.ts
+++ b/src/services/adopterService.ts
@@ -3,13 +3,32 @@ import { JSONFilePreset } from 'lowdb/node';
 
 const path = './src/db/adopters.json';
 
-
 interface Database {
   lastId: number;
   adopters: Adopter[];
 }
 
 export class AdopterService {
+  private static _lock: Promise<void> = Promise.resolve();
+
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    let release: () => void;
+    const wait = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    const previousLock = AdopterService._lock;
+    AdopterService._lock = previousLock.then(() => wait);
+
+    await previousLock;
+
+    try {
+      return await fn();
+    } finally {
+      release!();
+    }
+  }
+
   private async readDB(): Promise<Database> {
     const defaultData: Database = { lastId: 0, adopters: [] };
     try {
@@ -19,7 +38,6 @@ export class AdopterService {
         adopters: db.data.adopters ?? []
       };
     } catch {
-      // If the file doesn't exist or is invalid, return default structure
       return defaultData;
     }
   }
@@ -28,52 +46,59 @@ export class AdopterService {
     const defaultData: Database = { lastId: 0, adopters: [] };
     const db = await JSONFilePreset<Database>(path, defaultData);
     db.data = data;
-    db.write();
+    await db.write();
   }
 
   async getAdopter(id: number | undefined): Promise<Adopter | null> {
-    const db = await this.readDB();
-    if (id) { return db.adopters.find(adopter => adopter.id === id) || null; }
-    else return null;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      if (id) {
+        return db.adopters.find(adopter => adopter.id === id) || null;
+      }
+      return null;
+    });
   }
 
   async getAdopters(): Promise<Adopter[]> {
-    const db = await this.readDB();
-    return db.adopters;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      return db.adopters;
+    });
   }
 
   async addAdopter(adopter: Omit<Adopter, 'id'>): Promise<Adopter> {
-    const db = await this.readDB();
-
-    const newAdopter: Adopter = {
-      ...adopter,
-      id: db.lastId + 1
-    };
-
-    db.lastId = Number(newAdopter.id);
-    db.adopters.push(newAdopter);
-    await this.writeDB(db);
-    return newAdopter;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const newAdopter: Adopter = {
+        ...adopter,
+        id: db.lastId + 1
+      };
+      db.lastId = Number(newAdopter.id);
+      db.adopters.push(newAdopter);
+      await this.writeDB(db);
+      return newAdopter;
+    });
   }
 
-  async updateAdopter(adopter: Adopter): Promise<Adopter | null>{
-    const db = await this.readDB();
-    const index = db.adopters.findIndex(a => a.id === adopter.id);
-    if (index === -1) return null;
-    
-    db.adopters[index] = adopter;
-    await this.writeDB(db);
-    return db.adopters[index];
+  async updateAdopter(adopter: Adopter): Promise<Adopter | null> {
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const index = db.adopters.findIndex(a => a.id === adopter.id);
+      if (index === -1) return null;
+      db.adopters[index] = adopter;
+      await this.writeDB(db);
+      return db.adopters[index];
+    });
   }
 
   async removeAdopter(id: number): Promise<boolean> {
-    const db = await this.readDB();
-    const initialLength = db.adopters.length;
-    db.adopters = db.adopters.filter(adopter => adopter.id !== id);
-
-    if (db.adopters.length === initialLength) return false;
-    
-    await this.writeDB(db);
-    return true;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const initialLength = db.adopters.length;
+      db.adopters = db.adopters.filter(adopter => adopter.id !== id);
+      if (db.adopters.length === initialLength) return false;
+      await this.writeDB(db);
+      return true;
+    });
   }
 }

--- a/src/services/catService.ts
+++ b/src/services/catService.ts
@@ -9,6 +9,21 @@ interface Database {
 }
 
 export class CatService {
+  private static _lock: Promise<void> = Promise.resolve();
+
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    let release: () => void;
+    const wait = new Promise<void>(resolve => { release = resolve; });
+    const previousLock = CatService._lock;
+    CatService._lock = previousLock.then(() => wait);
+    await previousLock;
+    try {
+      return await fn();
+    } finally {
+      release!();
+    }
+  }
+
   private async readDB(): Promise<Database> {
     const defaultData: Database = { lastId: 0, cats: [] };
     try {
@@ -18,7 +33,6 @@ export class CatService {
         cats: db.data.cats ?? []
       };
     } catch {
-      // If the file doesn't exist or is invalid, return default structure
       return defaultData;
     }
   }
@@ -27,79 +41,88 @@ export class CatService {
     const defaultData: Database = { lastId: 0, cats: [] };
     const db = await JSONFilePreset<Database>(path, defaultData);
     db.data = data;
-    db.write();
+    await db.write();
   }
 
   async getCat(id: string): Promise<Cat | null> {
-    const db = await this.readDB();
-    return db.cats.find(cat => cat.id === parseInt(id)) || null;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      return db.cats.find(cat => cat.id === parseInt(id)) || null;
+    });
   }
 
   async getCatsByStaffId(staffId: string): Promise<Cat[]> {
-    const db = await this.readDB();
-    //eslint-disable-next-line
-    return (db.cats.filter(cat => cat.staffInCharge === staffId).map(({staffInCharge, ...rest}) => rest)) as Cat[];
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      return (db.cats.filter(cat => cat.staffInCharge === staffId).map(({ staffInCharge, ...rest }) => rest)) as Cat[];
+    });
   }
 
   async getCatsByAdopterId(adopterId: number): Promise<Cat[]> {
-    const db = await this.readDB();
-    //eslint-disable-next-line
-    return (db.cats.filter(cat => cat.adopterId === adopterId).map(({adopterId, ...rest}) => rest)) as Cat[];
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      return (db.cats.filter(cat => cat.adopterId === adopterId).map(({ adopterId, ...rest }) => rest)) as Cat[];
+    });
   }
 
   async getCats(): Promise<Cat[]> {
-    const db = await this.readDB();
-    return db.cats;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      return db.cats;
+    });
   }
 
   async addCat(cat: Omit<Cat, 'id'>): Promise<Cat> {
-    const db = await this.readDB();
-    
-    const newCat: Cat = {
-      ...cat,
-      id: db.lastId + 1,
-      dateJoined: new Date(cat.dateJoined)
-    };
-    
-    db.lastId = Number(newCat.id);
-    db.cats.push(newCat);
-    await this.writeDB(db);
-    return newCat;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const newCat: Cat = {
+        ...cat,
+        id: db.lastId + 1,
+        dateJoined: new Date(cat.dateJoined)
+      };
+      db.lastId = Number(newCat.id);
+      db.cats.push(newCat);
+      await this.writeDB(db);
+      return newCat;
+    });
   }
 
   async updateCat(cat: Cat): Promise<Cat | null> {
-    const db = await this.readDB();
-    const index = db.cats.findIndex(c => c.id === cat.id);
-    
-    if (index === -1) return null;
-    
-    db.cats[index] = cat;
-    await this.writeDB(db);
-    return db.cats[index];
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const index = db.cats.findIndex(c => c.id === cat.id);
+      if (index === -1) return null;
+      db.cats[index] = cat;
+      await this.writeDB(db);
+      return db.cats[index];
+    });
   }
 
   async removeCat(id: string): Promise<boolean> {
-    const db = await this.readDB();
-    const initialLength = db.cats.length;
-    db.cats = db.cats.filter(cat => cat.id !== parseInt(id));
-    
-    if (db.cats.length === initialLength) return false;
-    
-    await this.writeDB(db);
-    return true;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const initialLength = db.cats.length;
+      db.cats = db.cats.filter(cat => cat.id !== parseInt(id));
+      if (db.cats.length === initialLength) return false;
+      await this.writeDB(db);
+      return true;
+    });
   }
 
   async patchCat(id: string, staffInCharge: string | undefined, adopterId: number | undefined): Promise<Cat | null> {
-    const db = await this.readDB();
-    const index = db.cats.findIndex(c => c.id === parseInt(id));
-    if (index === -1) return null;
-  
-    if (staffInCharge) { db.cats[index].staffInCharge = staffInCharge; }
-    if (adopterId) { 
-      db.cats[index].adopterId = adopterId; 
-      db.cats[index].isAdopted = true;
-    }
-    await this.writeDB(db);
-    return db.cats[index];
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const index = db.cats.findIndex(c => c.id === parseInt(id));
+      if (index === -1) return null;
+      if (staffInCharge) { db.cats[index].staffInCharge = staffInCharge; }
+      if (adopterId) {
+        db.cats[index].adopterId = adopterId;
+        db.cats[index].isAdopted = true;
+      }
+      await this.writeDB(db);
+      return db.cats[index];
+    });
   }
 }

--- a/src/services/staffService.ts
+++ b/src/services/staffService.ts
@@ -8,9 +8,7 @@ interface Database {
 }
 
 function getDefaultDB(): Database {
-  const defaultDatabase: Database = {
-    staff: []
-  };
+  const defaultDatabase: Database = { staff: [] };
   const defaultStaff: Staff = {
     id: '00000000-0000-0000-0000-000000000000',
     name: 'The',
@@ -18,60 +16,79 @@ function getDefaultDB(): Database {
     age: 30,
     dateJoined: new Date('2021-01-01'),
     role: 'Boss'
-  }
+  };
   defaultDatabase.staff.push(defaultStaff);
   return defaultDatabase;
 }
 
 export class StaffService {
+  private static _lock: Promise<void> = Promise.resolve();
+
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    let release: () => void;
+    const wait = new Promise<void>(resolve => { release = resolve; });
+    const previousLock = StaffService._lock;
+    StaffService._lock = previousLock.then(() => wait);
+    await previousLock;
+    try {
+      return await fn();
+    } finally {
+      release!();
+    }
+  }
+
   private async readDB(): Promise<Database> {
-    try{
+    try {
       const db = await JSONFilePreset<Database>(path, getDefaultDB());
       return db.data;
-    } 
-    catch {
+    } catch {
       return getDefaultDB();
     }
   }
 
   private async writeDB(data: Database): Promise<void> {
-      const db = await JSONFilePreset<Database>(path, getDefaultDB());
-      db.data = data;
-      db.write();
+    const db = await JSONFilePreset<Database>(path, getDefaultDB());
+    db.data = data;
+    await db.write();
   }
 
   async getStaff(id: string | undefined): Promise<Staff | null> {
-    const db = await this.readDB();
-    if (id) { return db.staff.find(staff => staff.id === id) || null; }
-    else return null;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      if (id) return db.staff.find(staff => staff.id === id) || null;
+      return null;
+    });
   }
 
   async getAllStaff(): Promise<Staff[] | null> {
-    const db = await this.readDB();
-    return db.staff;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      return db.staff;
+    });
   }
 
   async addStaff(staff: Omit<Staff, 'id'>): Promise<Staff> {
-    const db = await this.readDB();
-    const newStaff: Staff = {
-      ...staff,
-      id: crypto.randomUUID(),
-      dateJoined: new Date(staff.dateJoined)
-    };
-    
-    db.staff.push(newStaff);
-    await this.writeDB(db);
-    return newStaff;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const newStaff: Staff = {
+        ...staff,
+        id: crypto.randomUUID(),
+        dateJoined: new Date(staff.dateJoined)
+      };
+      db.staff.push(newStaff);
+      await this.writeDB(db);
+      return newStaff;
+    });
   }
 
   async removeStaff(id: string): Promise<boolean> {
-    const db = await this.readDB();
-    const initialLength = db.staff.length;
-    db.staff = db.staff.filter(staff => staff.id !== id);
-    
-    if (db.staff.length === initialLength) return false;
-    
-    await this.writeDB(db);
-    return true;
+    return this.withLock(async () => {
+      const db = await this.readDB();
+      const initialLength = db.staff.length;
+      db.staff = db.staff.filter(staff => staff.id !== id);
+      if (db.staff.length === initialLength) return false;
+      await this.writeDB(db);
+      return true;
+    });
   }
 }


### PR DESCRIPTION
This pull request introduces a locking mechanism to ensure that database operations in the `AdopterService`, `CatService`, and `StaffService` classes are executed sequentially, avoiding potential race conditions. The most important changes include adding a static lock property and a `withLock` method to each service class, and wrapping all database operations within the `withLock` method.